### PR TITLE
Add JSON credential file and Preemptible VM support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,3 +4,6 @@ rvm:
   - 1.9.3
   - 2.0.0
   - 2.1.0
+
+before_install:
+  - gem update bundler

--- a/kitchen-gce.gemspec
+++ b/kitchen-gce.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |s|
   s.homepage    = 'https://github.com/anl/kitchen-gce'
   s.license     = 'Apache 2.0'
 
-  s.add_dependency 'fog', '>= 1.24.0'
+  s.add_dependency 'fog', '>= 1.31.0'
   s.add_dependency 'google-api-client'
   s.add_dependency 'ridley', '>= 3.0.0' # See GH issue RiotGames/ridley#239
   s.add_dependency 'test-kitchen'

--- a/lib/kitchen/driver/gce.rb
+++ b/lib/kitchen/driver/gce.rb
@@ -40,6 +40,7 @@ module Kitchen
       default_config :google_key_location, nil
       default_config :google_json_key_location, nil
       default_config :preemptible, false
+      default_config :auto_restart, false
 
       required_config :google_client_email
       required_config :google_project
@@ -122,7 +123,8 @@ module Kitchen
           public_key_path: config[:public_key_path],
           username: config[:username],
           preemptible: config[:preemptible],
-          on_host_maintenance: config[:preemptible] ? 'TERMINATE': 'MIGRATE'
+          on_host_maintenance: config[:preemptible] ? 'TERMINATE': 'MIGRATE',
+          auto_restart: config[:auto_restart]
         )
       end
 

--- a/lib/kitchen/driver/gce.rb
+++ b/lib/kitchen/driver/gce.rb
@@ -37,9 +37,10 @@ module Kitchen
       default_config :tags, []
       default_config :username, ENV['USER']
       default_config :zone_name, nil
+      default_config :google_key_location, nil
+      default_config :google_json_key_location, nil
 
       required_config :google_client_email
-      required_config :google_key_location
       required_config :google_project
       required_config :image_name
 
@@ -70,12 +71,20 @@ module Kitchen
       private
 
       def connection
-        Fog::Compute.new(
+        options = {
           provider: 'google',
           google_client_email: config[:google_client_email],
-          google_key_location: config[:google_key_location],
           google_project: config[:google_project]
-        )
+        }
+
+        [
+          :google_key_location,
+          :google_json_key_location
+        ].each do |k|
+          options[k] = config[k] unless config[k].nil?
+        end
+
+        Fog::Compute.new(options)
       end
 
       def create_disk

--- a/lib/kitchen/driver/gce.rb
+++ b/lib/kitchen/driver/gce.rb
@@ -39,6 +39,7 @@ module Kitchen
       default_config :zone_name, nil
       default_config :google_key_location, nil
       default_config :google_json_key_location, nil
+      default_config :preemptible, false
 
       required_config :google_client_email
       required_config :google_project
@@ -119,7 +120,9 @@ module Kitchen
           tags: config[:tags],
           zone_name: config[:zone_name],
           public_key_path: config[:public_key_path],
-          username: config[:username]
+          username: config[:username],
+          preemptible: config[:preemptible],
+          on_host_maintenance: config[:preemptible] ? 'TERMINATE': 'MIGRATE'
         )
       end
 

--- a/spec/kitchen/driver/gce_spec.rb
+++ b/spec/kitchen/driver/gce_spec.rb
@@ -24,7 +24,6 @@ describe Kitchen::Driver::Gce do
 
   let(:config) do
     { google_client_email: '123456789012@developer.gserviceaccount.com',
-      google_key_location: '/home/user/gce/123456-privatekey.p12',
       google_project: 'alpha-bravo-123'
     }
   end
@@ -43,7 +42,7 @@ describe Kitchen::Driver::Gce do
 
   let(:driver) do
     d = Kitchen::Driver::Gce.new(config)
-    d.instance = instance
+    allow(d).to receive(:instance) { instance }
     allow(d).to receive(:wait_for_sshd) { true }
     d
   end
@@ -90,7 +89,10 @@ describe Kitchen::Driver::Gce do
         service_accounts: nil,
         tags: [],
         username: ENV['USER'],
-        zone_name: nil }
+        zone_name: nil,
+        google_key_location: nil,
+        google_json_key_location: nil
+      }
 
       defaults.each do |k, v|
         it "sets the correct default for #{k}" do
@@ -111,7 +113,9 @@ describe Kitchen::Driver::Gce do
         service_accounts: %w(userdata.email compute.readonly),
         tags: %w(qa integration),
         username: 'root',
-        zone_name: 'europe-west1-a'
+        zone_name: 'europe-west1-a',
+        google_key_location: '/path/to/foo.p12',
+        google_json_key_location: '/path/to/bar.json'
       }
 
       let(:config) { overrides }

--- a/spec/kitchen/driver/gce_spec.rb
+++ b/spec/kitchen/driver/gce_spec.rb
@@ -91,7 +91,8 @@ describe Kitchen::Driver::Gce do
         username: ENV['USER'],
         zone_name: nil,
         google_key_location: nil,
-        google_json_key_location: nil
+        google_json_key_location: nil,
+        preemptible: false
       }
 
       defaults.each do |k, v|
@@ -115,7 +116,8 @@ describe Kitchen::Driver::Gce do
         username: 'root',
         zone_name: 'europe-west1-a',
         google_key_location: '/path/to/foo.p12',
-        google_json_key_location: '/path/to/bar.json'
+        google_json_key_location: '/path/to/bar.json',
+        preemptible: true
       }
 
       let(:config) { overrides }


### PR DESCRIPTION
Hi,

I want to add two options.

- Preemptible VM support  
This has a very cost benefit.
- JSON credential file support  
Currently, Google has recommended JSON format to credential file.  
And P12 is a format for backward compatibility.

They are already implemented in `fog-google`

![image](https://cloud.githubusercontent.com/assets/4560264/11804653/be7fca06-a348-11e5-859f-e982ff10dcf1.png)

And I fixed some error in the test together.
Please check them. 