### PR TITLE
Rake and rubocop fixes

### DIFF
--- a/kitchen-google.gemspec
+++ b/kitchen-google.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency "bundler"
   s.add_development_dependency "pry"
-  s.add_development_dependency "rake"
+  s.add_development_dependency "rake", "~> 10.5"
   s.add_development_dependency "rspec"
   s.add_development_dependency "rubocop"
 

--- a/lib/kitchen/driver/gce.rb
+++ b/lib/kitchen/driver/gce.rb
@@ -195,7 +195,7 @@ module Kitchen
       end
 
       def check_api_call(&block)
-        block.call
+        yield
       rescue Google::Apis::ClientError => e
         debug("API error: #{e.message}")
         false
@@ -471,7 +471,7 @@ module Kitchen
         begin
           Timeout.timeout(wait_time) do
             loop do
-              item = block.call
+              item = yield
               current_status = item.status
 
               unless last_status == current_status


### PR DESCRIPTION
Rake 11 causes rubocop / chefstyle to throw an error about `#last_comment`
not being a method. So, we'll pin to rake v10 for now.

Chefstyle is now pulling in rubocop 0.37.2, so this commit also takes
care of some new cops so Travis can go green again.