### PR TITLE
add_access_config configuration feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,8 +225,11 @@ Array of tags to associate with instance; default: `[]`
 ### `use_private_ip`
 
 Boolean indicating whether or not to connect to the instance using its
-private IP address. If `true`, kitchen-google will also not provision
-a public IP for this instance. Default: `false`
+private IP address. Default: `false`
+
+### `add_access_config`
+
+Boolean indicating whether to setup a [network access config](https://cloud.google.com/sdk/gcloud/reference/compute/instances/add-access-config) for the instance.  This also sets up a public IP.  Default: `true`
 
 ### `wait_time`
 

--- a/lib/kitchen/driver/gce.rb
+++ b/lib/kitchen/driver/gce.rb
@@ -99,6 +99,7 @@ module Kitchen
       default_config :image_project, nil
       default_config :email, nil
       default_config :use_private_ip, false
+      default_config :add_access_config, true
       default_config :wait_time, 600
       default_config :refresh_rate, 2
 
@@ -491,6 +492,8 @@ module Kitchen
       end
 
       def interface_access_configs
+        return [] if config[:add_access_config] == false
+
         access_config        = Google::Apis::ComputeV1::AccessConfig.new
         access_config.name   = "External NAT"
         access_config.type   = "ONE_TO_ONE_NAT"

--- a/lib/kitchen/driver/gce.rb
+++ b/lib/kitchen/driver/gce.rb
@@ -491,8 +491,6 @@ module Kitchen
       end
 
       def interface_access_configs
-        return [] if config[:use_private_ip]
-
         access_config        = Google::Apis::ComputeV1::AccessConfig.new
         access_config.name   = "External NAT"
         access_config.type   = "ONE_TO_ONE_NAT"

--- a/spec/kitchen/driver/gce_spec.rb
+++ b/spec/kitchen/driver/gce_spec.rb
@@ -906,7 +906,7 @@ describe Kitchen::Driver::Gce do
   end
 
   describe '#interface_access_configs' do
-    it "returns a properly-configured access config object" do
+    it "returns a properly-configured access config object if not specified" do
       access_config = double("access_config")
 
       expect(driver).to receive(:config).and_return({})
@@ -917,8 +917,8 @@ describe Kitchen::Driver::Gce do
       expect(driver.interface_access_configs).to eq([access_config])
     end
 
-    it "returns an empty array if use_private_ip is true" do
-      expect(driver).to receive(:config).and_return(use_private_ip: true)
+    it "returns an empty array if add_access_config is false" do
+      expect(driver).to receive(:config).and_return(add_access_config: false)
       expect(driver.interface_access_configs).to eq([])
     end
   end


### PR DESCRIPTION
When you specify the `use_private_ip=true` feature, it does not create an external IP, and does not set up a network access_config.

I have a use case where I'd like to use the private ip, but I would also like an access_config to be set up: We have a private internal network, and we'd like a chef test kitchen server to be able to provision and test another GCE instance over the private internal network.  But the instance needs a proper network access_config to be able to talk properly to the outside internet.

This PR adds that feature, updates the README, and updates the related spec tests.