### PR TITLE
Support configured custom metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,6 +248,18 @@ Amount of time, in seconds, to wait for any API interactions. Default: 600
 
 Amount of time, in seconds, to refresh the status of an API interaction. Default: 2
 
+### `metadata`
+
+Allows custom instance metadata to be set.
+The following metadata is set by default if no metadata configuration is provided:
+Default:
+
+
+    "created-by"            => "test-kitchen",
+    "test-kitchen-instance" => <instance.name>,
+    "test-kitchen-user"     => <env_user>,
+
+
 ### Transport Settings
 
 Beginning with Test Kitchen 1.4, settings related to the transport (i.e. how to connect
@@ -301,15 +313,27 @@ platforms:
     driver:
       image_project: centos-cloud
       image_name: centos-7-v20170124
+      metadata:
+        application: centos
+        release: a
+        version: 7
   - name: ubuntu-16.04
     driver:
       image_project: ubuntu-os-cloud
       image_family: ubuntu-1604-lts
+      metadata:
+        application: ubuntu
+        release: a
+        version: 1604
   - name: windows
     driver:
       image_project: windows-cloud
       image_name: windows-server-2012-r2-dc-v20170117
       disk_size: 50
+      metadata:
+        application: windows
+        release: a
+        version: cloud
 
 suites:
   - name: default

--- a/lib/kitchen/driver/gce.rb
+++ b/lib/kitchen/driver/gce.rb
@@ -101,6 +101,7 @@ module Kitchen
       default_config :use_private_ip, false
       default_config :wait_time, 600
       default_config :refresh_rate, 2
+      default_config :metadata, {}
 
       def name
         "Google Compute (GCE)"
@@ -450,13 +451,15 @@ module Kitchen
         "zones/#{zone}/machineTypes/#{config[:machine_type]}"
       end
 
-      def instance_metadata
-        metadata = {
-          "created-by"            => "test-kitchen",
-          "test-kitchen-instance" => instance.name,
-          "test-kitchen-user"     => env_user,
-        }
+      def metadata
+        config[:metadata].merge({
+                                    "created-by"            => "test-kitchen",
+                                    "test-kitchen-instance" => instance.name,
+                                    "test-kitchen-user"     => env_user,
+                                })
+      end
 
+      def instance_metadata
         Google::Apis::ComputeV1::Metadata.new.tap do |metadata_obj|
           metadata_obj.items = metadata.each_with_object([]) do |(k, v), memo|
             memo << Google::Apis::ComputeV1::Metadata::Item.new.tap do |item|

--- a/lib/kitchen/driver/gce.rb
+++ b/lib/kitchen/driver/gce.rb
@@ -200,7 +200,7 @@ module Kitchen
       end
 
       def winrm_transport?
-        instance.transport.name.downcase == "winrm"
+        instance.transport.name.casecmp("winrm").zero?
       end
 
       def update_windows_password(server_name)
@@ -416,7 +416,7 @@ module Kitchen
 
         latest_image = connection.list_images(image_project).items
           .select { |image| image.name.start_with?(image_prefix) }
-          .sort { |a, b| a.name <=> b.name }
+          .sort_by(&:name)
           .last
 
         return if latest_image.nil?

--- a/lib/kitchen/driver/gce.rb
+++ b/lib/kitchen/driver/gce.rb
@@ -386,8 +386,8 @@ module Kitchen
         Google::Apis::ComputeV1::Metadata.new.tap do |metadata_obj|
           metadata_obj.items = metadata.each_with_object([]) do |(k, v), memo|
             memo << Google::Apis::ComputeV1::Metadata::Item.new.tap do |item|
-              item.key   = k
-              item.value = v
+              item.key   = k.to_s
+              item.value = v.to_s
             end
           end
         end

--- a/spec/kitchen/driver/gce_spec.rb
+++ b/spec/kitchen/driver/gce_spec.rb
@@ -806,11 +806,12 @@ describe Kitchen::Driver::Gce do
   end
 
   describe '#instance_metadata' do
+    let(:item1   ) { double("item1") }
+    let(:item2   ) { double("item2") }
+    let(:item3   ) { double("item3") }
+    let(:metadata) { double("metadata") }
+
     it "returns a properly-configured metadata object" do
-      item1    = double("item1")
-      item2    = double("item2")
-      item3    = double("item3")
-      metadata = double("metadata")
 
       expect(instance).to receive(:name).and_return("instance_name")
       expect(driver).to receive(:env_user).and_return("env_user")
@@ -825,6 +826,32 @@ describe Kitchen::Driver::Gce do
       expect(item3).to receive(:key=).with("test-kitchen-user")
       expect(item3).to receive(:value=).with("env_user")
       expect(metadata).to receive(:items=).with([item1, item2, item3])
+
+      expect(driver.instance_metadata).to eq(metadata)
+    end
+
+    it "accepts custom metadata" do
+      foo = double("foo")
+      config[:metadata] = { 'foo' => 'bar' }
+
+      expect(instance).to receive(:name).and_return("instance_name")
+      expect(driver).to receive(:env_user).and_return("env_user")
+
+      expect(Google::Apis::ComputeV1::Metadata).to receive(:new).and_return(metadata)
+      expect(Google::Apis::ComputeV1::Metadata::Item).to receive(:new).and_return(foo)
+      expect(Google::Apis::ComputeV1::Metadata::Item).to receive(:new).and_return(item1)
+      expect(Google::Apis::ComputeV1::Metadata::Item).to receive(:new).and_return(item2)
+      expect(Google::Apis::ComputeV1::Metadata::Item).to receive(:new).and_return(item3)
+      expect(item1).to receive(:key=).with("created-by")
+      expect(item1).to receive(:value=).with("test-kitchen")
+      expect(item2).to receive(:key=).with("test-kitchen-instance")
+      expect(item2).to receive(:value=).with("instance_name")
+      expect(item3).to receive(:key=).with("test-kitchen-user")
+      expect(item3).to receive(:value=).with("env_user")
+      expect(foo).to receive(:key=).with("foo")
+      expect(foo).to receive(:value=).with("bar")
+
+      expect(metadata).to receive(:items=).with([foo, item1, item2, item3])
 
       expect(driver.instance_metadata).to eq(metadata)
     end

--- a/spec/kitchen/driver/gce_spec.rb
+++ b/spec/kitchen/driver/gce_spec.rb
@@ -78,13 +78,13 @@ describe Kitchen::Driver::Gce do
     expect(driver.diagnose_plugin[:api_version]).to eq(2)
   end
 
-  describe '#name' do
+  describe "#name" do
     it "has an overridden name" do
       expect(driver.name).to eq("Google Compute (GCE)")
     end
   end
 
-  describe '#create' do
+  describe "#create" do
     let(:connection) { double("connection") }
     let(:operation)  { double("operation", name: "test_operation") }
     let(:state)      { {} }
@@ -151,7 +151,7 @@ describe Kitchen::Driver::Gce do
     end
   end
 
-  describe '#destroy' do
+  describe "#destroy" do
     let(:connection) { double("connection") }
     let(:state)      { { server_name: "server_1", hostname: "test_host", zone: "test_zone" } }
 
@@ -187,7 +187,7 @@ describe Kitchen::Driver::Gce do
     end
   end
 
-  describe '#validate!' do
+  describe "#validate!" do
     let(:config) do
       {
         project:      "test_project",
@@ -306,7 +306,7 @@ describe Kitchen::Driver::Gce do
     end
   end
 
-  describe '#connection' do
+  describe "#connection" do
     it "returns a properly configured ComputeService" do
       compute_service = double("compute_service")
       client_options  = double("client_options")
@@ -324,7 +324,7 @@ describe Kitchen::Driver::Gce do
     end
   end
 
-  describe '#authorization' do
+  describe "#authorization" do
     it "returns a Google::Auth authorization object" do
       auth_object = double("auth_object")
       expect(Google::Auth).to receive(:get_application_default).and_return(auth_object)
@@ -332,7 +332,7 @@ describe Kitchen::Driver::Gce do
     end
   end
 
-  describe '#winrm_transport?' do
+  describe "#winrm_transport?" do
     it "returns true if the transport name is Winrm" do
       expect(transport).to receive(:name).and_return("Winrm")
       expect(driver.winrm_transport?).to eq(true)
@@ -344,7 +344,7 @@ describe Kitchen::Driver::Gce do
     end
   end
 
-  describe '#update_windows_password' do
+  describe "#update_windows_password" do
     it "does not attempt to reset the password if the transport is not WinRM" do
       expect(driver).to receive(:winrm_transport?).and_return(false)
       expect(GoogleComputeWindowsPassword).not_to receive(:new)
@@ -374,7 +374,7 @@ describe Kitchen::Driver::Gce do
     end
   end
 
-  describe '#check_api_call' do
+  describe "#check_api_call" do
     it "returns false and logs a debug message if the block raises a ClientError" do
       expect(driver).to receive(:debug).with("API error: whoops")
       expect(driver.check_api_call { raise Google::Apis::ClientError.new("whoops") }).to eq(false)
@@ -389,37 +389,37 @@ describe Kitchen::Driver::Gce do
     end
   end
 
-  describe '#valid_machine_type?' do
+  describe "#valid_machine_type?" do
     subject { driver.valid_machine_type? }
     it_behaves_like "a validity checker", :machine_type, :get_machine_type, "test_project", "test_zone"
   end
 
-  describe '#valid_network?' do
+  describe "#valid_network?" do
     subject { driver.valid_network? }
     it_behaves_like "a validity checker", :network, :get_network, "test_project"
   end
 
-  describe '#valid_subnet?' do
+  describe "#valid_subnet?" do
     subject { driver.valid_subnet? }
     it_behaves_like "a validity checker", :subnet, :get_subnetwork, "test_project", "test_region"
   end
 
-  describe '#valid_zone?' do
+  describe "#valid_zone?" do
     subject { driver.valid_zone? }
     it_behaves_like "a validity checker", :zone, :get_zone, "test_project"
   end
 
-  describe '#valid_region?' do
+  describe "#valid_region?" do
     subject { driver.valid_region? }
     it_behaves_like "a validity checker", :region, :get_region, "test_project"
   end
 
-  describe '#valid_disk_type?' do
+  describe "#valid_disk_type?" do
     subject { driver.valid_disk_type? }
     it_behaves_like "a validity checker", :disk_type, :get_disk_type, "test_project", "test_zone"
   end
 
-  describe '#image_exist?' do
+  describe "#image_exist?" do
     it "checks the outcome of the API call" do
       connection = double("connection")
       expect(driver).to receive(:connection).and_return(connection)
@@ -429,7 +429,7 @@ describe Kitchen::Driver::Gce do
     end
   end
 
-  describe '#server_exist?' do
+  describe "#server_exist?" do
     it "checks the outcome of the API call" do
       expect(driver).to receive(:server_instance).with("server_1")
       expect(driver).to receive(:check_api_call).and_call_original
@@ -437,7 +437,7 @@ describe Kitchen::Driver::Gce do
     end
   end
 
-  describe '#project' do
+  describe "#project" do
     it "returns the project from the config" do
       allow(driver).to receive(:project).and_call_original
       expect(driver).to receive(:config).and_return(project: "my_project")
@@ -445,7 +445,7 @@ describe Kitchen::Driver::Gce do
     end
   end
 
-  describe '#region' do
+  describe "#region" do
     it "returns the region from the config if specified" do
       allow(driver).to receive(:region).and_call_original
       allow(driver).to receive(:config).and_return(region: "my_region")
@@ -460,7 +460,7 @@ describe Kitchen::Driver::Gce do
     end
   end
 
-  describe '#region_for_zone' do
+  describe "#region_for_zone" do
     it "returns the region for a given zone" do
       connection = double("connection")
       zone_obj   = double("zone_obj", region: "/path/to/test_region")
@@ -471,7 +471,7 @@ describe Kitchen::Driver::Gce do
     end
   end
 
-  describe '#zone' do
+  describe "#zone" do
     before do
       allow(driver).to receive(:zone).and_call_original
     end
@@ -505,7 +505,7 @@ describe Kitchen::Driver::Gce do
     end
   end
 
-  describe '#find_zone' do
+  describe "#find_zone" do
     let(:zones_in_region) { double("zones_in_region") }
 
     before do
@@ -525,7 +525,7 @@ describe Kitchen::Driver::Gce do
     end
   end
 
-  describe '#zones_in_region' do
+  describe "#zones_in_region" do
     it "returns a correct list of available zones" do
       zone1      = double("zone1", status: "UP", region: "a/b/c/test_region")
       zone2      = double("zone2", status: "UP", region: "a/b/c/test_region")
@@ -542,7 +542,7 @@ describe Kitchen::Driver::Gce do
     end
   end
 
-  describe '#server_instance' do
+  describe "#server_instance" do
     it "returns the instance from the API" do
       connection = double("connection")
       expect(driver).to receive(:connection).and_return(connection)
@@ -551,7 +551,7 @@ describe Kitchen::Driver::Gce do
     end
   end
 
-  describe '#ip_address_for' do
+  describe "#ip_address_for" do
     it "returns the private IP if use_private_ip is true" do
       expect(driver).to receive(:config).and_return(use_private_ip: true)
       expect(driver).to receive(:private_ip_for).with("server").and_return("1.2.3.4")
@@ -565,7 +565,7 @@ describe Kitchen::Driver::Gce do
     end
   end
 
-  describe '#private_ip_for' do
+  describe "#private_ip_for" do
     it "returns the IP address if it exists" do
       network_interface = double("network_interface", network_ip: "1.2.3.4")
       server            = double("server", network_interfaces: [network_interface])
@@ -581,7 +581,7 @@ describe Kitchen::Driver::Gce do
     end
   end
 
-  describe '#public_ip_for' do
+  describe "#public_ip_for" do
     it "returns the IP address if it exists" do
       access_config     = double("access_config", nat_ip: "4.3.2.1")
       network_interface = double("network_interface", access_configs: [access_config])
@@ -599,7 +599,7 @@ describe Kitchen::Driver::Gce do
     end
   end
 
-  describe '#generate_server_name' do
+  describe "#generate_server_name" do
     it "generates and returns a server name" do
       expect(instance).to receive(:name).and_return("ABC123")
       expect(SecureRandom).to receive(:hex).with(3).and_return("abcdef")
@@ -615,7 +615,7 @@ describe Kitchen::Driver::Gce do
     end
   end
 
-  describe '#boot_disk' do
+  describe "#boot_disk" do
     it "sets up a disk object and returns it" do
       disk    = double("disk")
       params  = double("params")
@@ -644,13 +644,13 @@ describe Kitchen::Driver::Gce do
     end
   end
 
-  describe '#disk_type_url_for' do
+  describe "#disk_type_url_for" do
     it "returns a disk URL" do
       expect(driver.disk_type_url_for("my_type")).to eq("zones/test_zone/diskTypes/my_type")
     end
   end
 
-  describe '#disk_image_url' do
+  describe "#disk_image_url" do
     before do
       allow(driver).to receive(:config).and_return(config)
     end
@@ -714,7 +714,7 @@ describe Kitchen::Driver::Gce do
     end
   end
 
-  describe '#image_url_for' do
+  describe "#image_url_for" do
     it "returns nil if the image does not exist" do
       expect(driver).to receive(:image_exist?).with("image_project", "image_name").and_return(false)
       expect(driver.image_url_for("image_project", "image_name")).to eq(nil)
@@ -726,7 +726,7 @@ describe Kitchen::Driver::Gce do
     end
   end
 
-  describe '#image_alias_url' do
+  describe "#image_alias_url" do
     before do
       allow(driver).to receive(:config).and_return(config)
     end
@@ -780,7 +780,7 @@ describe Kitchen::Driver::Gce do
     end
   end
 
-  describe '#public_project_for_image' do
+  describe "#public_project_for_image" do
     {
       "centos"         => "centos-cloud",
       "container-vm"   => "google-containers",
@@ -798,14 +798,14 @@ describe Kitchen::Driver::Gce do
     end
   end
 
-  describe '#machine_type_url' do
+  describe "#machine_type_url" do
     it "returns a machine type URL" do
       expect(driver).to receive(:config).and_return(machine_type: "machine_type")
       expect(driver.machine_type_url).to eq("zones/test_zone/machineTypes/machine_type")
     end
   end
 
-  describe '#instance_metadata' do
+  describe "#instance_metadata" do
     let(:item1   ) { double("item1") }
     let(:item2   ) { double("item2") }
     let(:item3   ) { double("item3") }
@@ -857,7 +857,7 @@ describe Kitchen::Driver::Gce do
     end
   end
 
-  describe '#env_user' do
+  describe "#env_user" do
     it "returns the current user from the environment" do
       expect(ENV).to receive(:[]).with("USER").and_return("test_user")
       expect(driver.env_user).to eq("test_user")
@@ -869,7 +869,7 @@ describe Kitchen::Driver::Gce do
     end
   end
 
-  describe '#instance_network_interfaces' do
+  describe "#instance_network_interfaces" do
     let(:interface) { double("interface") }
 
     before do
@@ -912,14 +912,14 @@ describe Kitchen::Driver::Gce do
     end
   end
 
-  describe '#network_url' do
+  describe "#network_url" do
     it "returns a network URL" do
       expect(driver).to receive(:config).and_return(network: "test_network")
       expect(driver.network_url).to eq("projects/test_project/global/networks/test_network")
     end
   end
 
-  describe '#subnet_url_for' do
+  describe "#subnet_url_for" do
     it "returns nil if no subnet is specified" do
       expect(driver).to receive(:config).and_return({})
       expect(driver.subnet_url).to eq(nil)
@@ -932,7 +932,7 @@ describe Kitchen::Driver::Gce do
     end
   end
 
-  describe '#interface_access_configs' do
+  describe "#interface_access_configs" do
     it "returns a properly-configured access config object" do
       access_config = double("access_config")
 
@@ -950,7 +950,7 @@ describe Kitchen::Driver::Gce do
     end
   end
 
-  describe '#instance_scheduling' do
+  describe "#instance_scheduling" do
     it "returns a properly-configured scheduling object" do
       scheduling = double("scheduling")
 
@@ -965,14 +965,14 @@ describe Kitchen::Driver::Gce do
     end
   end
 
-  describe '#preemptible?' do
+  describe "#preemptible?" do
     it "returns the preemptible setting from the config" do
       expect(driver).to receive(:config).and_return(preemptible: "test_preempt")
       expect(driver.preemptible?).to eq("test_preempt")
     end
   end
 
-  describe '#auto_migrate?' do
+  describe "#auto_migrate?" do
     it "returns false if the instance is preemptible" do
       expect(driver).to receive(:preemptible?).and_return(true)
       expect(driver.auto_migrate?).to eq(false)
@@ -985,7 +985,7 @@ describe Kitchen::Driver::Gce do
     end
   end
 
-  describe '#auto_restart?' do
+  describe "#auto_restart?" do
     it "returns false if the instance is preemptible" do
       expect(driver).to receive(:preemptible?).and_return(true)
       expect(driver.auto_restart?).to eq(false)
@@ -998,7 +998,7 @@ describe Kitchen::Driver::Gce do
     end
   end
 
-  describe '#migrate_setting' do
+  describe "#migrate_setting" do
     it "returns MIGRATE if auto_migrate is true" do
       expect(driver).to receive(:auto_migrate?).and_return(true)
       expect(driver.migrate_setting).to eq("MIGRATE")
@@ -1010,7 +1010,7 @@ describe Kitchen::Driver::Gce do
     end
   end
 
-  describe '#instance_service_accounts' do
+  describe "#instance_service_accounts" do
     it "returns nil if service_account_scopes is nil" do
       allow(driver).to receive(:config).and_return({})
       expect(driver.instance_service_accounts).to eq(nil)
@@ -1038,7 +1038,7 @@ describe Kitchen::Driver::Gce do
     end
   end
 
-  describe '#service_account_scope_url' do
+  describe "#service_account_scope_url" do
     it "returns the passed-in scope if it already looks like a scope URL" do
       scope = "https://www.googleapis.com/auth/fake_scope"
       expect(driver.service_account_scope_url(scope)).to eq(scope)
@@ -1050,7 +1050,7 @@ describe Kitchen::Driver::Gce do
     end
   end
 
-  describe '#translate_scope_alias' do
+  describe "#translate_scope_alias" do
     it "returns a scope for a given alias" do
       expect(driver.translate_scope_alias("storage-rw")).to eq("devstorage.read_write")
     end
@@ -1060,7 +1060,7 @@ describe Kitchen::Driver::Gce do
     end
   end
 
-  describe '#instance_tags' do
+  describe "#instance_tags" do
     it "returns a properly-formatted tags object" do
       tags_obj = double("tags_obj")
 
@@ -1072,21 +1072,21 @@ describe Kitchen::Driver::Gce do
     end
   end
 
-  describe '#wait_time' do
+  describe "#wait_time" do
     it "returns the configured wait time" do
       expect(driver).to receive(:config).and_return(wait_time: 123)
       expect(driver.wait_time).to eq(123)
     end
   end
 
-  describe '#refresh_rate' do
+  describe "#refresh_rate" do
     it "returns the configured refresh rate" do
       expect(driver).to receive(:config).and_return(refresh_rate: 321)
       expect(driver.refresh_rate).to eq(321)
     end
   end
 
-  describe '#wait_for_status' do
+  describe "#wait_for_status" do
     let(:item) { double("item") }
 
     before do
@@ -1130,7 +1130,7 @@ describe Kitchen::Driver::Gce do
     end
   end
 
-  describe '#wait_for_operation' do
+  describe "#wait_for_operation" do
     let(:operation) { double("operation", name: "operation-123") }
 
     it "raises a properly-formatted exception when errors exist" do
@@ -1153,7 +1153,7 @@ describe Kitchen::Driver::Gce do
     end
   end
 
-  describe '#zone_operation' do
+  describe "#zone_operation" do
     it "fetches the operation from the API and returns it" do
       connection = double("connection")
       expect(driver).to receive(:connection).and_return(connection)
@@ -1162,7 +1162,7 @@ describe Kitchen::Driver::Gce do
     end
   end
 
-  describe '#operation_errors' do
+  describe "#operation_errors" do
     let(:operation) { double("operation") }
     let(:error_obj) { double("error_obj") }
 

--- a/spec/kitchen/driver/gce_spec.rb
+++ b/spec/kitchen/driver/gce_spec.rb
@@ -381,7 +381,7 @@ describe Kitchen::Driver::Gce do
     end
 
     it "raises an exception if the block raises something other than a ClientError" do
-      expect { driver.check_api_call { raise RuntimeError.new("whoops") } }.to raise_error(RuntimeError)
+      expect { driver.check_api_call { raise "whoops" } }.to raise_error(RuntimeError)
     end
 
     it "returns true if the block does not raise an exception" do
@@ -832,7 +832,7 @@ describe Kitchen::Driver::Gce do
 
     it "accepts custom metadata" do
       foo = double("foo")
-      config[:metadata] = { 'foo' => 'bar' }
+      config[:metadata] = { "foo" => "bar" }
 
       expect(instance).to receive(:name).and_return("instance_name")
       expect(driver).to receive(:env_user).and_return("env_user")


### PR DESCRIPTION
I need the ability to set custom metadata via the .kitchen.yml. 
With this addition one would be able to set driver:metadata in the driver_config or platform:driver 
