### PR TITLE
Add support for Google Shared VPC Networks (XPN)

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,9 +199,17 @@ GCE instance type (size) to launch; default: `n1-standard-1`
 
 GCE network that instance will be attached to; default: `default`
 
+### `network_project`
+
+GCE project which network belongs to; default is same as `project`
+
 ### `subnet`
 
 GCE subnetwork that instance will be attached to. Only applies to custom networks.
+
+### `subnet_project`
+
+GCE project which subnet belongs to. Only applies when `subnet` is used; default is same as `project`
 
 ### `preemptible`
 

--- a/lib/kitchen/driver/gce.rb
+++ b/lib/kitchen/driver/gce.rb
@@ -529,13 +529,11 @@ module Kitchen
       end
 
       def wait_for_server
-        begin
-          instance.transport.connection(state).wait_until_ready
-        rescue
-          error("Server not reachable. Destroying server...")
-          destroy(state)
-          raise
-        end
+        instance.transport.connection(state).wait_until_ready
+      rescue
+        error("Server not reachable. Destroying server...")
+        destroy(state)
+        raise
       end
 
       def zone_operation(operation_name)

--- a/lib/kitchen/driver/gce.rb
+++ b/lib/kitchen/driver/gce.rb
@@ -157,7 +157,7 @@ module Kitchen
         warn("Both zone and region specified - region will be ignored.") if config[:zone] && config[:region]
         warn("Both image family and name specified - image family will be ignored") if config[:image_family] && config[:image_name]
         warn("Image project not specified - searching current project only") unless config[:image_project]
-        #warn("Subnet project not specified - searching current project only") unless config[:subnet_project]
+        warn("Subnet project not specified - searching current project only") if config[:subnet] && !config[:subnet_project]
         warn("Auto-migrate disabled for preemptible instance") if preemptible? && config[:auto_migrate]
         warn("Auto-restart disabled for preemptible instance") if preemptible? && config[:auto_restart]
       end

--- a/lib/kitchen/driver/gce_version.rb
+++ b/lib/kitchen/driver/gce_version.rb
@@ -18,6 +18,6 @@
 
 module Kitchen
   module Driver
-    GCE_VERSION = "1.2.0".freeze
+    GCE_VERSION = "1.2.1".freeze
   end
 end

--- a/lib/kitchen/driver/gce_version.rb
+++ b/lib/kitchen/driver/gce_version.rb
@@ -18,6 +18,6 @@
 
 module Kitchen
   module Driver
-    GCE_VERSION = "1.2.1".freeze
+    GCE_VERSION = "1.2.0".freeze
   end
 end

--- a/spec/kitchen/driver/gce_spec.rb
+++ b/spec/kitchen/driver/gce_spec.rb
@@ -790,9 +790,18 @@ describe Kitchen::Driver::Gce do
   end
 
   describe "#network_url" do
-    it "returns a network URL" do
-      expect(driver).to receive(:config).and_return(network: "test_network")
-      expect(driver.network_url).to eq("projects/test_project/global/networks/test_network")
+    context "when the user does not provide network_project" do
+      it "returns a network URL" do
+        allow(driver).to receive(:config).and_return(network: "test_network")
+        expect(driver.network_url).to eq("projects/test_project/global/networks/test_network")
+      end
+    end
+
+    context "when the user provides network_project" do
+      it "returns a network URL" do
+        allow(driver).to receive(:config).and_return(network: "test_network", network_project: "test_xpn_project")
+        expect(driver.network_url).to eq("projects/test_xpn_project/global/networks/test_network")
+      end
     end
   end
 
@@ -802,10 +811,20 @@ describe Kitchen::Driver::Gce do
       expect(driver.subnet_url).to eq(nil)
     end
 
-    it "returns a properly-formatted subnet URL" do
-      allow(driver).to receive(:config).and_return(subnet: "test_subnet")
-      expect(driver).to receive(:region).and_return("test_region")
-      expect(driver.subnet_url).to eq("projects/test_project/regions/test_region/subnetworks/test_subnet")
+    context "when the user does not provide subnet_project" do
+      it "returns a properly-formatted subnet URL" do
+        allow(driver).to receive(:config).and_return(subnet: "test_subnet")
+        expect(driver).to receive(:region).and_return("test_region")
+        expect(driver.subnet_url).to eq("projects/test_project/regions/test_region/subnetworks/test_subnet")
+      end
+    end
+
+    context "when the user provides subnet_project" do
+      it "returns a properly-formatted subnet URL" do
+        allow(driver).to receive(:config).and_return(subnet_project: "test_xpn_project", subnet: "test_subnet")
+        expect(driver).to receive(:region).and_return("test_region")
+        expect(driver.subnet_url).to eq("projects/test_xpn_project/regions/test_region/subnetworks/test_subnet")
+      end
     end
   end
 


### PR DESCRIPTION
[Shared VPC](https://cloud.google.com/compute/docs/shared-vpc/) network was previously know as Cross-Project Networking (XPN).

This PR adds support to provision instances into shared networks and subnetworks.