### PR TITLE
Inject ssh key for test-kitchen-user using Google Cloud metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,6 +248,12 @@ Amount of time, in seconds, to wait for any API interactions. Default: 600
 
 Amount of time, in seconds, to refresh the status of an API interaction. Default: 2
 
+### `ssh_pub_key`
+
+Path to public key which will be passed to instance through metadata.
+Current shell session user is used as ssh user passed to metadata.
+It should match private key `ssh_key` declared in `transport` section. 
+
 ### Transport Settings
 
 Beginning with Test Kitchen 1.4, settings related to the transport (i.e. how to connect

--- a/lib/kitchen/driver/gce.rb
+++ b/lib/kitchen/driver/gce.rb
@@ -530,13 +530,11 @@ module Kitchen
       end
 
       def wait_for_server
-        begin
-          instance.transport.connection(state).wait_until_ready
-        rescue
-          error("Server not reachable. Destroying server...")
-          destroy(state)
-          raise
-        end
+        instance.transport.connection(state).wait_until_ready
+      rescue
+        error("Server not reachable. Destroying server...")
+        destroy(state)
+        raise
       end
 
       def zone_operation(operation_name)


### PR DESCRIPTION
This PR lets test-kitchen to inject public key from provided file (path) and allow `env_user` to connect to virtual machine using this public key.

I have no idea how to write proper tests for this.