### PR TITLE
Changing SSH Command

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Alternatively, the Google Cloud SDK (a.k.a. `gcloud`) will create a SSH key
 for you when you create and access your first instance:
 
  1. Create a small test instance:
-    `gcloud compute instances create instance1 --zone us-central1-f --image debian-8 --machine-type g1-small`
+    `gcloud compute instances create instance1 --zone us-central1-f --image-family=debian-8 --image-project=debian-cloud --machine-type g1-small`
  1. Ensure your SSH keys allow access to the new instance
     `gcloud compute ssh instance1 --zone us-central1-f`
  1. Log out and delete the instance

--- a/lib/kitchen/driver/gce.rb
+++ b/lib/kitchen/driver/gce.rb
@@ -165,7 +165,7 @@ module Kitchen
         @connection = Google::Apis::ComputeV1::ComputeService.new
         @connection.authorization = authorization
         @connection.client_options = Google::Apis::ClientOptions.new.tap do |opts|
-          opts.application_name    = "kitchen-google"
+          opts.application_name    = "GoogleChefTestKitchen"
           opts.application_version = Kitchen::Driver::GCE_VERSION
         end
 

--- a/spec/kitchen/driver/gce_spec.rb
+++ b/spec/kitchen/driver/gce_spec.rb
@@ -329,7 +329,7 @@ describe Kitchen::Driver::Gce do
       client_options  = double("client_options")
 
       expect(Google::Apis::ClientOptions).to receive(:new).and_return(client_options)
-      expect(client_options).to receive(:application_name=).with("kitchen-google")
+      expect(client_options).to receive(:application_name=).with("GoogleChefTestKitchen")
       expect(client_options).to receive(:application_version=).with(Kitchen::Driver::GCE_VERSION)
 
       expect(Google::Apis::ComputeV1::ComputeService).to receive(:new).and_return(compute_service)


### PR DESCRIPTION
The command for setting up SSH Keys uses a deprecated flag. It'll be removed eventually.