### PR TITLE
Option to override instance names

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,15 @@ Example: `us-central1`
 
 This parameter will be ignored if `zone` is specified.
 
+### `inst_name`
+
+**Optional** Name to give to instance. If given, must be under 63 characters
+in length. Any character that is not alphanumeric or a hyphen will be converted
+to a hyphen. Unlike EC2's "Name" tag, this is used as an instance identifier and
+must be unique.  By default, a unique name will be auto-generated; note that
+auto-generated names must be used if there is more than one test suite.  Default:
+`tk-<suite>-<platform>-<UUID>`
+
 ### `autodelete_disk`
 
 Boolean specifying whether or not to automatically delete boot disk

--- a/lib/kitchen/driver/gce.rb
+++ b/lib/kitchen/driver/gce.rb
@@ -327,7 +327,11 @@ module Kitchen
       end
 
       def generate_server_name
-        name = "tk-#{instance.name.downcase}-#{SecureRandom.hex(3)}"
+        name = if config[:inst_name]
+                 config[:inst_name]
+               else
+                 "tk-#{instance.name.downcase}-#{SecureRandom.hex(3)}"
+               end
 
         if name.length > 63
           warn("The TK instance name (#{instance.name}) has been removed from the GCE instance name due to size limitations. Consider setting shorter platform or suite names.")

--- a/spec/kitchen/driver/gce_spec.rb
+++ b/spec/kitchen/driver/gce_spec.rb
@@ -630,6 +630,12 @@ describe Kitchen::Driver::Gce do
       expect(SecureRandom).to receive(:uuid).and_return("lmnop")
       expect(driver.generate_server_name).to eq("tk-lmnop")
     end
+
+    it "returns a specific name for the server if given in the config" do
+      config[:inst_name] = "the_instance_name"
+
+      expect(driver.generate_server_name).to eq("the-instance-name")
+    end
   end
 
   describe "#boot_disk" do


### PR DESCRIPTION
The return of the inst_name option. Added back to generate_server_name to take advantage of the existing length and valid character checks.

This is an alternative to #37 whose fork has disappeared making it difficult to test and merge.
