### PR TITLE
Require Ruby 2.3+ and remove test files from the Gem

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ branches:
   only:
   - master
 rvm:
-  - 2.2.10
   - 2.3.7
   - 2.4.4
   - 2.5.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,10 @@
-## [v1.6.0](https://github.com/test-kitchen/kitchen-google/tree/v1.6.0)
+## [v2.0.0](https://github.com/test-kitchen/kitchen-google/tree/v2.0.0)
 
-[Full Changelog](https://github.com/test-kitchen/kitchen-google/compare/v1.5.0...v1.6.0)
+[Full Changelog](https://github.com/test-kitchen/kitchen-google/compare/v1.5.0...v2.0.0)
 
  * #59: Add support for GCE instance labels
+ * Require Ruby 2.3 or later
+ * Reduced the number of files we ship in the Gem to reduce install size
  * Resolve minor Chefstyle warnings
  * Simplify and loosen dev deps
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ providers, GCE has a couple of advantages for Chef cookbook testing:
 
 ### Ruby Version
 
-Ruby 2.0 or greater.
+Ruby 2.3 or greater.
 
 ### Google Cloud Platform (GCP) Project
 A [Google Cloud Platform](https://cloud.google.com) account is
@@ -287,7 +287,7 @@ Default:
 
 ### Disk configuration
 
-NOTE: In order to support multiple disks in this driver, the disk configuration has been reworked. However, old .kitchen-files will keep working and simply be adapted automatically. 
+NOTE: In order to support multiple disks in this driver, the disk configuration has been reworked. However, old .kitchen-files will keep working and simply be adapted automatically.
 
 ```yaml
 driver:

--- a/kitchen-google.gemspec
+++ b/kitchen-google.gemspec
@@ -5,14 +5,16 @@ require "kitchen/driver/gce_version"
 Gem::Specification.new do |s|
   s.name        = "kitchen-google"
   s.version     = Kitchen::Driver::GCE_VERSION
-  s.date        = "2016-03-10"
   s.summary     = "Kitchen::Driver::Gce"
   s.description = "A Test-Kitchen driver for Google Compute Engine"
   s.authors     = ["Andrew Leonard", "Chef Partner Engineering"]
   s.email       = ["andy@hurricane-ridge.com", "partnereng@chef.io"]
-  s.files       = `git ls-files`.split($/)
   s.homepage    = "https://github.com/test-kitchen/kitchen-google"
   s.license     = "Apache-2.0"
+
+  s.files         = `git ls-files`.split($INPUT_RECORD_SEPARATOR).grep(/LICENSE|^CHANGELOG|^lib/)
+  s.test_files    = s.files.grep(%r{^(test|spec|features)/})
+  s.require_paths = ["lib"]
 
   s.add_dependency "gcewinpass",        "~> 1.1"
   s.add_dependency "google-api-client", "~> 0.19"
@@ -24,5 +26,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rspec"
   s.add_development_dependency "byebug"
 
-  s.required_ruby_version = ">= 2.0"
+  s.required_ruby_version = ">= 2.3"
 end

--- a/lib/kitchen/driver/gce_version.rb
+++ b/lib/kitchen/driver/gce_version.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Chef Partner Engineering (<partnereng@chef.io>)
-# Copyright:: Copyright (c) 2015 Chef Software, Inc.
+# Copyright:: Copyright (c) 2015-2018 Chef Software, Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -18,6 +18,6 @@
 
 module Kitchen
   module Driver
-    GCE_VERSION = "1.5.0".freeze
+    GCE_VERSION = "2.0.0".freeze
   end
 end


### PR DESCRIPTION
Signed-off-by: Tim Smith <tsmith@chef.io>