### PR TITLE
Optimize our requires

### DIFF
--- a/lib/kitchen/driver/gce.rb
+++ b/lib/kitchen/driver/gce.rb
@@ -21,7 +21,7 @@ require "gcewinpass"
 require "google/apis/compute_v1"
 require "kitchen"
 require_relative "gce_version"
-require "securerandom"
+require "securerandom" unless defined?(SecureRandom)
 
 module Kitchen
   module Driver


### PR DESCRIPTION
Avoid requiring things that are already defined. Rubygems is very slow at traversing the filesystem.

Signed-off-by: Tim Smith <tsmith@chef.io>