### PR TITLE
Add suport for `networkIP`

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,11 @@ GCE instance type (size) to launch; default: `n1-standard-1`
 
 GCE network that instance will be attached to; default: `default`
 
+### `network_ip`
+
+An IPv4 internal IP address to assign to the instance. If not specified, an
+unused internal IP is automatically assigned.
+
 ### `network_project`
 
 GCE project which network belongs to; default is same as `project`

--- a/lib/kitchen/driver/gce.rb
+++ b/lib/kitchen/driver/gce.rb
@@ -62,6 +62,7 @@ module Kitchen
 
       default_config :machine_type, "n1-standard-1"
       default_config :network, "default"
+      default_config :network_ip, nil
       default_config :network_project, nil
       default_config :subnet, nil
       default_config :subnet_project, nil
@@ -361,6 +362,10 @@ module Kitchen
         config[:network_project].nil? ? project : config[:network_project]
       end
 
+      def network_ip
+        config[:network_ip]
+      end
+
       def region
         config[:region].nil? ? region_for_zone : config[:region]
       end
@@ -571,6 +576,7 @@ module Kitchen
       def instance_network_interfaces
         interface                = Google::Apis::ComputeV1::NetworkInterface.new
         interface.network        = network_url if config[:subnet_project].nil?
+        interface.network_ip     = network_ip unless network_ip.nil?
         interface.subnetwork     = subnet_url if subnet_url
         interface.access_configs = interface_access_configs
 

--- a/spec/kitchen/driver/gce_spec.rb
+++ b/spec/kitchen/driver/gce_spec.rb
@@ -951,6 +951,7 @@ describe Kitchen::Driver::Gce do
       allow(driver).to receive(:subnet_url)
       allow(driver).to receive(:interface_access_configs)
       allow(interface).to receive(:network=)
+      allow(interface).to receive(:network_ip=)
       allow(interface).to receive(:subnetwork=)
       allow(interface).to receive(:access_configs=)
     end
@@ -969,6 +970,18 @@ describe Kitchen::Driver::Gce do
     it "sets the access configs" do
       expect(driver).to receive(:interface_access_configs).and_return("access_configs")
       expect(interface).to receive(:access_configs=).with("access_configs")
+      driver.instance_network_interfaces
+    end
+
+    it "does not set a network ip by default" do
+      allow(driver).to receive(:network_ip).and_return(nil)
+      expect(interface).not_to receive(:network_ip=)
+      driver.instance_network_interfaces
+    end
+
+    it "sets a network ip if one was specified" do
+      allow(driver).to receive(:network_ip).and_return("10.142.0.2")
+      expect(interface).to receive(:network_ip=).with("10.142.0.2")
       driver.instance_network_interfaces
     end
 


### PR DESCRIPTION
# Description

Add suport for `networkIP` when creating a GCE instance https://cloud.google.com/compute/docs/reference/rest/v1/instances/insert#request-body

This is useful if you want a kitchen setup with private networking.

## Issues Resolved

List any existing issues this PR resolves

## Check List

- [ ] All tests pass. See TESTING.md for details.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
