### PR TITLE
Update google-client-api pin

### DIFF
--- a/kitchen-google.gemspec
+++ b/kitchen-google.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_dependency "gcewinpass",        "~> 1.1"
-  s.add_dependency "google-api-client", ">= 0.23.9", "< 0.37.0"
+  s.add_dependency "google-api-client", ">= 0.23.9", "<= 0.52.0"
   s.add_dependency "test-kitchen"
 
   s.add_development_dependency "bundler"


### PR DESCRIPTION
# Description

Update the Google client API pin, which among other things allows testing under Ruby 3.0.

## Issues Resolved


## Check List

- [ ] All tests pass. See TESTING.md for details.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
