### PR TITLE
Remove support for Ruby 2.3 since google's api is 2.4+

### DIFF
--- a/kitchen-google.gemspec
+++ b/kitchen-google.gemspec
@@ -24,5 +24,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rspec"
   s.add_development_dependency "byebug"
 
-  s.required_ruby_version = ">= 2.3"
+  s.required_ruby_version = ">= 2.4"
 end


### PR DESCRIPTION
This never actually worked

Signed-off-by: Tim Smith <tsmith@chef.io>