### PR TITLE
Require Ruby 2.5 and standardize some of the testing

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -1,0 +1,30 @@
+---
+name: linters
+
+'on':
+  pull_request:
+  push:
+    branches:
+      - master
+
+jobs:
+  yamllint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@master
+      - name: Run yaml Lint
+        uses: actionshub/yamllint@main
+  chefstyle:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        ruby: ['2.5', '2.6', '2.7', '3.0']
+    name: Chefstyle on Ruby ${{ matrix.ruby }}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+          bundler-cache: true
+      - run: bundle exec rake style

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -1,6 +1,7 @@
-name: CI
+---
+name: Unit
 
-on:
+'on':
   pull_request:
   push:
     branches:
@@ -11,12 +12,12 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: [ '2.5', '2.6', '2.7', '3.0']
-    name: Lint & Test with Ruby ${{ matrix.ruby }}
+        ruby: ['2.5', '2.6', '2.7', '3.0']
+    name: Unit test on Ruby ${{ matrix.ruby }}
     steps:
       - uses: actions/checkout@v2
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
-      - run: bundle exec rake
+      - run: bundle exec rake test

--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,3 @@
+--color
+--require spec_helper
+--format documentation

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,4 @@
+---
+AllCops:
+  TargetRubyVersion: 2.5
+

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,4 +1,3 @@
 ---
 AllCops:
   TargetRubyVersion: 2.5
-

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,1 @@
+Please refer to the Chef Community Code of Conduct at https://www.chef.io/code-of-conduct/

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,18 @@
 source "https://rubygems.org"
 
-# Specify dependencies in gemspec:
+# Specify your gem's dependencies in kitchen-google.gemspec
 gemspec
 
-gem "chefstyle"
+group :test do
+  gem "rake", ">= 11.0"
+  gem "rspec", "~> 3.2"
+end
+
+group :debug do
+  gem "pry"
+  gem "byebug"
+end
+
+group :chefstyle do
+  gem "chefstyle", "=1.5.9"
+end

--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
 # Kitchen::Gce - A Test Kitchen Driver for Google Compute Engine
 
-![CI](https://github.com/test-kitchen/kitchen-google/workflows/CI/badge.svg)
-[![Code Climate](https://codeclimate.com/github/test-kitchen/kitchen-google.svg)](https://codeclimate.com/github/test-kitchen/kitchen-google)
 [![Gem Version](https://badge.fury.io/rb/kitchen-google.svg)](https://badge.fury.io/rb/kitchen-google)
+![CI](https://github.com/test-kitchen/kitchen-google/workflows/CI/badge.svg?branch=master)
 
 This is a [Test Kitchen](https://github.com/test-kitchen/test-kitchen)
 driver for Google Compute Engine.  While similar to EC2 and other IaaS
@@ -15,7 +14,7 @@ providers, GCE has a couple of advantages for Chef cookbook testing:
 
 ### Ruby Version
 
-Ruby 2.3 or greater.
+Ruby 2.5 or greater.
 
 ### Google Cloud Platform (GCP) Project
 A [Google Cloud Platform](https://cloud.google.com) account is

--- a/Rakefile
+++ b/Rakefile
@@ -1,12 +1,15 @@
 require "bundler/gem_tasks"
 require "rspec/core/rake_task"
+RSpec::Core::RakeTask.new(:test)
 
-RSpec::Core::RakeTask.new(:spec)
-
-require "chefstyle"
-require "rubocop/rake_task"
-RuboCop::RakeTask.new(:style) do |task|
-  task.options << "--display-cop-names"
+begin
+  require "chefstyle"
+  require "rubocop/rake_task"
+  RuboCop::RakeTask.new(:style) do |task|
+    task.options += ["--display-cop-names", "--no-color"]
+  end
+rescue LoadError
+  puts "chefstyle is not available. (sudo) gem install chefstyle to do style checking."
 end
 
-task default: %i{spec style}
+task default: %i{test style}

--- a/kitchen-google.gemspec
+++ b/kitchen-google.gemspec
@@ -16,13 +16,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency "gcewinpass",        "~> 1.1"
   s.add_dependency "google-api-client", ">= 0.23.9", "<= 0.52.0"
-  s.add_dependency "test-kitchen"
-
-  s.add_development_dependency "bundler"
-  s.add_development_dependency "pry"
-  s.add_development_dependency "rake"
-  s.add_development_dependency "rspec"
-  s.add_development_dependency "byebug"
+  s.add_dependency "test-kitchen",      ">= 1.4.1"
 
   s.required_ruby_version = ">= 2.5"
 end

--- a/kitchen-google.gemspec
+++ b/kitchen-google.gemspec
@@ -24,5 +24,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rspec"
   s.add_development_dependency "byebug"
 
-  s.required_ruby_version = ">= 2.4"
+  s.required_ruby_version = ">= 2.5"
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -18,3 +18,17 @@
 require "rspec"
 
 require_relative "../lib/kitchen/driver/gce"
+
+RSpec.configure do |config|
+  # Run specs in random order to surface order dependencies. If you find an
+  # order dependency and want to debug it, you can fix the order by providing
+  # the seed, which is printed after each run.
+  #     --seed 1234
+  config.order = :random
+
+  # Seed global randomization in this process using the `--seed` CLI option.
+  # Setting this allows you to use `--seed` to deterministically reproduce
+  # test failures related to randomization by passing the same `--seed` value
+  # as the one that triggered the failure.
+  Kernel.srand config.seed
+end


### PR DESCRIPTION
Require a supported Ruby release and bring in some of the standard testing setups from the other repos.