### PR TITLE
add support for ruby 3.1 and EOL for 2.5

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,9 @@
+---
+
 version: 2
 updates:
-- package-ecosystem: bundler
-  directory: "/"
-  schedule:
-    interval: daily
-  open-pull-requests-limit: 10
+  - package-ecosystem: bundler
+    directory: "/"
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 10

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -5,21 +5,21 @@ name: linters
   pull_request:
   push:
     branches:
-      - master
+      - main
 
 jobs:
   yamllint:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@master
+        uses: actions/checkout@main
       - name: Run yaml Lint
         uses: actionshub/yamllint@main
   chefstyle:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: ['2.5', '2.6', '2.7', '3.0']
+        ruby: ['2.6']
     name: Chefstyle on Ruby ${{ matrix.ruby }}
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -5,14 +5,14 @@ name: Unit
   pull_request:
   push:
     branches:
-      - master
+      - main
 
 jobs:
   test:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: ['2.5', '2.6', '2.7', '3.0']
+        ruby: ['2.6', '2.7', '3.0', '3.1']
     name: Unit test on Ruby ${{ matrix.ruby }}
     steps:
       - uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ providers, GCE has a couple of advantages for Chef cookbook testing:
 
 ### Ruby Version
 
-Ruby 2.5 or greater.
+Ruby 2.6 or greater.
 
 ## Installation
 

--- a/kitchen-google.gemspec
+++ b/kitchen-google.gemspec
@@ -18,5 +18,5 @@ Gem::Specification.new do |s|
   s.add_dependency "google-api-client", ">= 0.23.9", "<= 0.54.0"
   s.add_dependency "test-kitchen",      ">= 1.4.1"
 
-  s.required_ruby_version = ">= 2.5"
+  s.required_ruby_version = ">= 2.6"
 end


### PR DESCRIPTION
Signed-off-by: kasif <kadnan@progress.com>

# Description

This PR adds ruby 3.1 support and removes 2.5 support

## Issues Resolved

List any existing issues this PR resolves

## Check List

- [ ] All tests pass. See TESTING.md for details.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
