### PR TITLE
Release 2.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Change Log
 
+## [v2.3.0](https://github.com/test-kitchen/kitchen-google/tree/v2.3.0)
+
+[Full Changelog](https://github.com/test-kitchen/kitchen-google/compare/v2.2.0...v2.3.0)
+
+- Added support for Ruby 3.1 and ended support for Ruby 2.5 [@kasif-adnan](https://github.com/kasif-adnan)
+- Github workflow updates [@kasif-adnan](https://github.com/kasif-adnan)
+- Use chefsyle linting [@sanjain-progress](https://github.com/sanjain-progress)
+- Updated google-api-client and chefsyle
+
 ## [v2.2.0](https://github.com/test-kitchen/kitchen-google/tree/v2.2.0)
 
 [Full Changelog](https://github.com/test-kitchen/kitchen-google/compare/v2.1.0...v2.2.0)

--- a/lib/kitchen/driver/gce_version.rb
+++ b/lib/kitchen/driver/gce_version.rb
@@ -18,6 +18,6 @@
 
 module Kitchen
   module Driver
-    GCE_VERSION = "2.2.0".freeze
+    GCE_VERSION = "2.3.0".freeze
   end
 end


### PR DESCRIPTION
Signed-off-by: Ashique P S <Ashique.saidalavi@progress.com>

# Description
Release 2.3.0

The changes include: 
- Added support for Ruby 3.1 and ended support for Ruby 2.5
- Github workflow updates
- Use chefsyle linting
- Updated google-api-client and chefsyle

## Issues Resolved

List any existing issues this PR resolves, or any Discourse or
StackOverflow discussions that are relevant

## Type of Change

Our release process assumes you are using [Conventional Commit messages](https://www.conventionalcommits.org/en/v1.0.0/).

The most important prefixes you should have in mind are:

- `_fix_`: which represents bug fixes, and correlates to a SemVer patch.
- `_feat_`: which represents a new feature, and correlates to a SemVer minor.
- `_feat!_`:, or `fix!:`, `refactor!:`, etc., which represent a breaking change (indicated by the !) and will result in a major version change.

If you have not included a conventional commit message this can be fixed on merge.

## Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] Commit message includes a [Conventional Commit Message](https://www.conventionalcommits.org/en/v1.0.0)
