### PR TITLE
feat: add support for (optional) guest accelerator(s) configuration

### DIFF
--- a/lib/kitchen/driver/gce.rb
+++ b/lib/kitchen/driver/gce.rb
@@ -552,13 +552,13 @@ module Kitchen
           guest_accelerator_obj = Google::Apis::ComputeV1::AcceleratorConfig.new
           guest_accelerator_obj.accelerator_type = "zones/#{zone}/acceleratorTypes/#{guest_accelerator[:type]}"
 
+          count = 1
+
           if guest_accelerator.has_key?(:count)
             count = guest_accelerator[:count]
-
-            if count > 0
-              guest_accelerator_obj.accelerator_count = count
-            end
           end
+
+          guest_accelerator_obj.accelerator_count = count
 
           guest_accelerator_configs << guest_accelerator_obj
         end

--- a/lib/kitchen/driver/gce.rb
+++ b/lib/kitchen/driver/gce.rb
@@ -547,14 +547,14 @@ module Kitchen
         guest_accelerator_configs = []
 
         guest_accelerators.each do |guest_accelerator|
-          next unless guest_accelerator.has_key?(:type)
+          next unless guest_accelerator.key?(:type)
 
           guest_accelerator_obj = Google::Apis::ComputeV1::AcceleratorConfig.new
           guest_accelerator_obj.accelerator_type = "zones/#{zone}/acceleratorTypes/#{guest_accelerator[:type]}"
 
           count = 1
 
-          if guest_accelerator.has_key?(:count)
+          if guest_accelerator.key?(:count)
             count = guest_accelerator[:count]
           end
 


### PR DESCRIPTION
Add support for (optional) guest accelerator(s) configuration, eg.

```
driver:
  name: gce
...
  machine_type: n1-standard-4
  guest_accelerators:
    - type: nvidia-tesla-t4-vws
```

```
driver:
  name: gce
...
  machine_type: n1-standard-4
  guest_accelerators:
    - type: nvidia-tesla-t4
       count: 2
```

Why is this useful for Test Kitchen usage? Well, in some cases -eg. when installing GPU-specific drivers and tools- an actual GPU needs to be present. There are other guest accelerators obviously, so it will be helpful for non-GPU use cases as well.

Please let me know if anything else is required or you need additional info to get this merged in.

Kind regards,
David @ Escape Technology