### PR TITLE
Update to use the google-apis-compute_v1 directly

### DIFF
--- a/kitchen-google.gemspec
+++ b/kitchen-google.gemspec
@@ -14,9 +14,9 @@ Gem::Specification.new do |s|
   s.files         = %w{LICENSE} + Dir.glob("lib/**/*")
   s.require_paths = ["lib"]
 
-  s.add_dependency "gcewinpass",        "~> 1.1"
-  s.add_dependency "google-api-client", ">= 0.23.9", "<= 0.54.0"
-  s.add_dependency "test-kitchen",      ">= 1.4.1"
+  s.add_dependency "gcewinpass",             "~> 1.1"
+  s.add_dependency "google-apis-compute_v1", ">= 0.75"
+  s.add_dependency "test-kitchen",           ">= 1.4.1"
 
   s.required_ruby_version = ">= 2.7"
 end


### PR DESCRIPTION
The previous all-in-one google API gem hasn't been updated in two years.