### PR TITLE
Add configurable winpass_timeout for Windows password reset and migrate Chefstyle to Cookstyle

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,6 @@
 ---
 require:
-  - chefstyle
+  - cookstyle/chefstyle
 
 AllCops:
   TargetRubyVersion: 3.1

--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,6 @@ group :debug do
   gem "pry"
 end
 
-group :chefstyle do
-  gem "chefstyle", "2.2.3"
+group :cookstyle do
+  gem "cookstyle", "~> 8.7"
 end

--- a/Rakefile
+++ b/Rakefile
@@ -3,13 +3,13 @@ require "rspec/core/rake_task"
 RSpec::Core::RakeTask.new(:test)
 
 begin
-  require "chefstyle"
+  require "cookstyle/chefstyle"
   require "rubocop/rake_task"
   RuboCop::RakeTask.new(:style) do |task|
     task.options += ["--display-cop-names", "--no-color"]
   end
 rescue LoadError
-  puts "chefstyle is not available. (sudo) gem install chefstyle to do style checking."
+  puts "cookstyle/chefstyle is not available. (sudo) gem install cookstyle to do style checking."
 end
 
 task default: %i{test style}

--- a/lib/kitchen/driver/gce.rb
+++ b/lib/kitchen/driver/gce.rb
@@ -80,6 +80,7 @@ module Kitchen
       default_config :use_private_ip, false
       default_config :wait_time, 600
       default_config :refresh_rate, 2
+      default_config :winpass_timeout, nil
       default_config :guest_accelerators, []
       default_config :metadata, {}
       default_config :labels, {}
@@ -271,13 +272,15 @@ module Kitchen
 
         info("Resetting the Windows password for user #{username} on #{server_name}...")
 
-        state[:password] = GoogleComputeWindowsPassword.new(
-          project:,
-          zone:,
+        opts = {
+          project:       project,
+          zone:          zone,
           instance_name: server_name,
           email:         config[:email],
-          username:
-        ).new_password
+          username:      username,
+        }
+        opts[:timeout] = config[:winpass_timeout] unless config[:winpass_timeout].nil?
+        state[:password] = GoogleComputeWindowsPassword.new(**opts).new_password
 
         info("Password reset complete on #{server_name} complete.")
       end

--- a/lib/kitchen/driver/gce.rb
+++ b/lib/kitchen/driver/gce.rb
@@ -273,11 +273,11 @@ module Kitchen
         info("Resetting the Windows password for user #{username} on #{server_name}...")
 
         opts = {
-          project:       project,
-          zone:          zone,
+          project: project,
+          zone: zone,
           instance_name: server_name,
-          email:         config[:email],
-          username:      username,
+          email: config[:email],
+          username: username,
         }
         opts[:timeout] = config[:winpass_timeout] unless config[:winpass_timeout].nil?
         state[:password] = GoogleComputeWindowsPassword.new(**opts).new_password
@@ -530,7 +530,7 @@ module Kitchen
       end
 
       def image_url(image = image_name)
-        return "projects/#{image_project}/global/images/#{image}" if image_exist?(image)
+        "projects/#{image_project}/global/images/#{image}" if image_exist?(image)
       end
 
       def image_name_for_family(image_family)

--- a/spec/kitchen/driver/gce_spec.rb
+++ b/spec/kitchen/driver/gce_spec.rb
@@ -395,12 +395,46 @@ describe Kitchen::Driver::Gce do
 
       allow(driver).to receive(:state).and_return(state)
       expect(transport).to receive(:config).and_return(username: "test_username")
-      expect(driver).to receive(:config).and_return(email: "test_email")
+      allow(driver).to receive(:config).and_return(email: "test_email", winpass_timeout: nil)
       expect(driver).to receive(:winrm_transport?).and_return(true)
       expect(GoogleComputeWindowsPassword).to receive(:new).with(winpass_config).and_return(winpass)
       expect(winpass).to receive(:new_password).and_return("password123")
       driver.update_windows_password("server_1")
       expect(state[:password]).to eq("password123")
+    end
+
+    it "passes the winpass_timeout config to gcewinpass when set" do
+      state   = {}
+      winpass = double("winpass")
+
+      allow(driver).to receive(:state).and_return(state)
+      expect(transport).to receive(:config).and_return(username: "test_username")
+      allow(driver).to receive(:config).and_return(email: "test_email", winpass_timeout: 300)
+      expect(driver).to receive(:winrm_transport?).and_return(true)
+      expect(GoogleComputeWindowsPassword).to receive(:new).with(
+        hash_including(timeout: 300)
+      ).and_return(winpass)
+      expect(winpass).to receive(:new_password).and_return("password123")
+      driver.update_windows_password("server_1")
+    end
+
+    it "does not pass timeout when winpass_timeout is not set in config" do
+      state   = {}
+      winpass = double("winpass")
+
+      allow(driver).to receive(:state).and_return(state)
+      expect(transport).to receive(:config).and_return(username: "test_username")
+      allow(driver).to receive(:config).and_return(email: "test_email", winpass_timeout: nil)
+      expect(driver).to receive(:winrm_transport?).and_return(true)
+      expect(GoogleComputeWindowsPassword).to receive(:new).with(
+        hash_not_including(:timeout)
+      ).and_return(winpass)
+      expect(winpass).to receive(:new_password).and_return("password123")
+      driver.update_windows_password("server_1")
+    end
+
+    it "defaults winpass_timeout config to nil" do
+      expect(driver.send(:config)[:winpass_timeout]).to be_nil
     end
   end
 


### PR DESCRIPTION
## Description

Adds a new `winpass_timeout` configuration option to allow users to specify a custom timeout (in seconds) for the Windows password reset operation performed by `gcewinpass`.

This fixes the `Timeout::Error: Timeout while waiting for password agent to perform password reset` error that occurs when the GCE Windows password agent takes longer than the default timeout to initialize.

## Changes

- Added `winpass_timeout` config option (defaults to `nil`, preserving backward compatibility)
- When set, the timeout value is passed to `GoogleComputeWindowsPassword`
- Added unit tests for the new configuration option

## Example `kitchen.yml`

```yaml
---
driver:
  name: gce
  project: my-gcp-project
  zone: us-central1-a
  email: user@example.com
  machine_type: n1-standard-2
  disk_size: 80
  metadata:
    serial-port-enable: "true"

provisioner:
  name: chef_infra
  product_name: chef
  wait_for_retry: 5
  max_retries: 600

platforms:
  - name: windows-2022
    driver:
      winpass_timeout: 300
      image_project: my-gcp-project
      image_name: my-windows-image
      image_os_type: windows

transport:
  name: winrm
  port: 5985
  username: my_user

suites:
  - name: default
    run_list:
    verifier:
      name: inspec
```

## Before (without `winpass_timeout`)

```
$ kitchen create
-----> Starting Chef Test Kitchen (v2.0.15)
-----> Creating <default-windows-2022>...
$$$$$$ These configs are deprecated - consider using new disks configuration
       Creating GCE instance <tk-default-windows-2022-ded241> in project my-gcp-project, zone us-central1-a...
       Creating a 80 GB boot disk named tk-default-windows-2022-ded241-disk1 from image my-windows-image...
       Current status: RUNNING
       Current status: DONE
       Server <tk-default-windows-2022-ded241> created.
       Resetting the Windows password for user my_user on tk-default-windows-2022-ded241...
>>>>>> Error encountered during server creation: Timeout::Error: Timeout while waiting for password agent to perform password reset
       Destroying GCE instance <tk-default-windows-2022-ded241>...
       Current status: RUNNING
       Current status: DONE
       GCE instance <tk-default-windows-2022-ded241> destroyed.
>>>>>> ------Exception-------
>>>>>> Class: Kitchen::ActionFailed
>>>>>> Message: 1 actions failed.
>>>>>>     Failed to complete #create action: [Timeout while waiting for password agent to perform password reset] on default-windows-2022
>>>>>> ----------------------
>>>>>> Please see .kitchen/logs/kitchen.log for more details
>>>>>> Also try running `kitchen diagnose --all` for configuration
```

## After (with `winpass_timeout: 300`)

```
$ kitchen create
-----> Starting Chef Test Kitchen (v2.0.15)
-----> Creating <default-windows-2022>...
$$$$$$ These configs are deprecated - consider using new disks configuration
       Creating GCE instance <tk-default-windows-2022-ba40ed> in project my-gcp-project, zone us-central1-a...
       Creating a 80 GB boot disk named tk-default-windows-2022-ba40ed-disk1 from image my-windows-image...
       Current status: RUNNING
       Current status: DONE
       Server <tk-default-windows-2022-ba40ed> created.
       Resetting the Windows password for user my_user on tk-default-windows-2022-ba40ed...
       Password reset complete on tk-default-windows-2022-ba40ed complete.
       Waiting for server <tk-default-windows-2022-ba40ed> to be ready...
       [WinRM] Established

       GCE instance <tk-default-windows-2022-ba40ed> created and ready.
       Finished creating <default-windows-2022> (4m2.25s).
```

## Related Issue

Fixes https://github.com/test-kitchen/kitchen-google/issues/117
